### PR TITLE
cmd/link: allow deriving GNU build ID from action ID

### DIFF
--- a/src/cmd/link/doc.go
+++ b/src/cmd/link/doc.go
@@ -18,6 +18,8 @@ Flags:
 	-B note
 		Add an ELF_NT_GNU_BUILD_ID note when using ELF.
 		The value should start with 0x and be an even number of hex digits.
+		Alternatively, you can pass "actionid" in order to derive the GNU build ID
+		from the Go build ID's action ID.
 	-E entry
 		Set entry symbol name.
 	-H type

--- a/src/cmd/link/internal/ld/elf.go
+++ b/src/cmd/link/internal/ld/elf.go
@@ -806,6 +806,23 @@ func elfwritefreebsdsig(out *OutBuf) int {
 }
 
 func addbuildinfo(val string) {
+	if val == "actionid" {
+		buildID := *flagBuildid
+		if buildID == "" {
+			Exitf("-B actionid requires a Go build ID supplied via -buildid")
+		}
+
+		if !strings.Contains(buildID, "/") {
+			Exitf("-B actionid does not contain content ID")
+		}
+
+		actionID := buildID[:strings.Index(buildID, "/")]
+		hashedID := notsha256.Sum256([]byte(actionID))
+		buildinfo = hashedID[:20]
+
+		return
+	}
+
 	if !strings.HasPrefix(val, "0x") {
 		Exitf("-B argument must start with 0x: %s", val)
 	}

--- a/src/cmd/link/internal/ld/main.go
+++ b/src/cmd/link/internal/ld/main.go
@@ -149,7 +149,7 @@ func Main(arch *sys.Arch, theArch Arch) {
 	flag.Var(&ctxt.LinkMode, "linkmode", "set link `mode`")
 	flag.Var(&ctxt.BuildMode, "buildmode", "set build `mode`")
 	flag.BoolVar(&ctxt.compressDWARF, "compressdwarf", true, "compress DWARF if possible")
-	objabi.Flagfn1("B", "add an ELF NT_GNU_BUILD_ID `note` when using ELF", addbuildinfo)
+	objabi.Flagfn1("B", "add an ELF NT_GNU_BUILD_ID `note` when using ELF; use \"actionid\" to generate it from the Go build ID", addbuildinfo)
 	objabi.Flagfn1("L", "add specified `directory` to library path", func(a string) { Lflag(ctxt, a) })
 	objabi.AddVersionFlag() // -V
 	objabi.Flagfn1("X", "add string value `definition` of the form importpath.name=value", func(s string) { addstrdata1(ctxt, s) })


### PR DESCRIPTION
While it is possible to embed a GNU build ID into the linked executable by passing `-B 0xBUILDID` to the linker, the build ID will need to be precomputed by the build system somehow. This makes it unnecessarily complex to generate a deterministic build ID as it either requires the biuld system to hash all inputs manually or to build the binary twice, once to compute its hash and once with the GNU build ID derived from that hash. Despite being complex, it is also inefficient as it requires the build system to duplicate some of the work that the Go linker already performs anyway.

Introduce a new argument "actionid" that can be passed to `-B` that causes the linker to automatically derive the build ID from the Go build ID's action ID, which is derived from all build inputs. This should thus both be deterministic while the value also changes whenever the build inputs change, which is the desired behaviour for the GNU build ID.

Furthermore, given that the `-B` flag currently requires a "0x" prefix for all values passed to it, using "actionid" as value is a backwards compatible change.

Fixes #41004